### PR TITLE
fix: VARDATA_ANY was moved from postgres.h to varatt.h on PG-16

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -31,7 +31,7 @@
 #include "utils/builtins.h"
 #include "utils/datetime.h"
 
-// Start from PG-16, VARDATA_ANY was moved from postgres.hto varatt.h
+// Start from PG-16, VARDATA_ANY was moved from postgres.h to varatt.h
 #if PG_VERSION_NUM >= 160000
 #include "varatt.h"
 #endif

--- a/sslutils.c
+++ b/sslutils.c
@@ -31,6 +31,11 @@
 #include "utils/builtins.h"
 #include "utils/datetime.h"
 
+// Start from PG-16, VARDATA_ANY was moved from postgres.hto varatt.h
+#if PG_VERSION_NUM >= 160000
+#include "varatt.h"
+#endif
+
 #define SERIAL_RAND_BITS  64
 #define VALIDITY_DAYS  3650
 


### PR DESCRIPTION
As per the discussion on https://edb.slack.com/archives/CDTA6PCJV/p1691542861490949, VARDATA_ANY was moved from postgres.h to varatt.h on PG-16 (and onwards).

The change has been verified on Debian/Ubuntu/RHEL amd64 platforms.