### PR TITLE
chore: compliance with OpenSSL 1.0.2

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -37,20 +37,17 @@
 #include "varatt.h"
 #endif
 
-// For compatibility with OpenSSL 1.0.2
-// OpenSSL 1.0.2 declares X509_get_notBefore as a function, instead of a preprocessor macro as in newer versions
-#ifndef X509_get_notBefore
+/*
+ * For compatibility with OpenSSL 1.0.2
+ *
+ * OpenSSL 1.0.2 has no function like X509_get0_notBefore, it has X509_get_notBefore instead
+ */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define X509_get0_notBefore X509_get_notBefore
-#endif
-#ifndef X509_get_notAfter
 #define X509_get0_notAfter X509_get_notAfter
-#endif
-#ifndef X509_CRL_set_nextUpdate
 #define X509_CRL_set1_nextUpdate X509_CRL_set_nextUpdate
-#endif
-#ifndef X509_CRL_set_lastUpdate
 #define X509_CRL_set1_lastUpdate X509_CRL_set_lastUpdate
-#endif
+#endif // if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 #define SERIAL_RAND_BITS  64
 #define DEDAULT_VALIDITY_DAYS  3650

--- a/sslutils.c
+++ b/sslutils.c
@@ -38,16 +38,17 @@
 #endif
 
 // For compatibility with OpenSSL 1.0.2
-#ifndef X509_get0_notBefore
+// OpenSSL 1.0.2 declares X509_get_notBefore as a function, instead of a preprocessor macro as in newer versions
+#ifndef X509_get_notBefore
 #define X509_get0_notBefore X509_get_notBefore
 #endif
-#ifndef X509_get0_notAfter
+#ifndef X509_get_notAfter
 #define X509_get0_notAfter X509_get_notAfter
 #endif
-#ifndef X509_CRL_set1_nextUpdate
+#ifndef X509_CRL_set_nextUpdate
 #define X509_CRL_set1_nextUpdate X509_CRL_set_nextUpdate
 #endif
-#ifndef X509_CRL_set1_lastUpdate
+#ifndef X509_CRL_set_lastUpdate
 #define X509_CRL_set1_lastUpdate X509_CRL_set_lastUpdate
 #endif
 


### PR DESCRIPTION
To be compliant with OpenSSL 1.0.2 (which doesn't have function like X509_get0_notBefore), using `OPENSSL_VERSION_NUMBER` is better than code like `#ifndef X509_get0_notAfter`, because `X509_get0_notAfter` is a function instead of a macro in newer version, means even the function is declared, `#ifndef X509_get0_notAfter` is still true.

The reason why using `OPENSSL_VERSION_NUMBER < 0x10100000L` instead of checking directly with `1.0.2` version, is because `OPENSSL_VERSION_NUMBER` includes a patch version like `0x1000207fL`