### PR TITLE
fix(PEM-6031): Stack-Based Buffer Overflow via Unbounded Field Parsing in openssl_revoke_certificate()

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -1442,9 +1442,11 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 		p = line;
 
 		int k = 0;
-		while ((token = string_sep(&p, sep)) != NULL)
+		while ((token = string_sep(&p, sep)) != NULL && k < DB_NUMBER)
 		{
-			strncpy(fields[k++], token, sizeof(fields[0]) - 1);
+			strncpy(fields[k], token, sizeof(fields[0]) - 1);
+			fields[k][sizeof(fields[0]) - 1] = '\0';
+			k++;
 		}
 
 		r = X509_REVOKED_new();


### PR DESCRIPTION
This PR is to fix a potential buffer overflow in `openssl_revoke_certificate()`, the function is to read/parse content from `PG_DATA_DIR/revoke_cert.db`.

Previously without checking the boundary, we haven't seen any buffer overflow, because the `revoke_cert.db` file is written by SSLUtils extension in revoke(), with fixed format and always has 6 fields only (`\t` separated, as below). 
```
R	460430131247Z	260505131247Z	DF534FC8329E1594	unknown	/C=US/ST=MA/L=Bedford/O=EnterpriseDB Corporation/OU=EDB Postgres Enterprise Manager/CN=PEM/emailAddress=packaging@enterprisedb.com
```

If the file is manually edited, there is a chance of buffer overflow. One good thing is that `openssl_revoke_certificate()` is reading the file line by line, a maximum of 512 bytes, so basically it won't overflow too much.
Still it'd be better to check the boundary to avoid buffer overflow.

Dev package to test (on RHEL/9/arm64): `1.4-0.0snapshot25369462741.356.1.4f28abd.1.el9`

Test command:
```
SSL_CERT=$(cat ${PG_DATA_DIR}/server.crt)
psql ... SELECT public.openssl_revoke_certificate('${SSL_CERT}', '${PG_DATA_DIR}/revoked.crl', 365);
```
Check result:
```
openssl crl -in ${PG_DATA_DIR}/revoked.crl -text
```