### PR TITLE
fix(PEM-6032): validate input file path to be under PGDATA for sslutils functions

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -147,7 +147,7 @@ static char* string_sep(char **stringp, const char *delim)
 }
 
 /*
- * This function is to restrict all file access to $PGDATA or a designated subdirectory
+ * This function is to restrict all file access to be under $PGDATA
  */
 static bool validate_path_within_datadir(const char *path)
 {
@@ -751,7 +751,6 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	BIO        *bio = NULL;
 	RSA        *ca_key = NULL;
 	char       *err = NULL;
-	char errBuffer[512] = {0};
 	X509_REQ   *req = NULL;
 	X509       *ca_cert = NULL;
 	char       *data = NULL;
@@ -781,7 +780,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		ca_cert_file_path = PG_GETARG_TEXT_PP(1);
 		if (!validate_path_within_datadir(text_to_cstring(ca_cert_file_path)))
 		{
-			err = "PATH_NOT_IN_PGDATA-2";
+			err = "PATH_NOT_IN_PGDATA";
 			goto out;
 		}
 
@@ -808,7 +807,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
 	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
 	{
-		snprintf(errBuffer, sizeof(errBuffer), "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, text_to_cstring(ca_key_file_path));
+		err = "PATH_NOT_IN_PGDATA";
 		goto out;
 	}
 
@@ -1016,8 +1015,6 @@ out:
 		X509_EXTENSION_free(extension);
 	if (serial_no != NULL)
 		ASN1_INTEGER_free(serial_no);
-	if (errBuffer[0] != 0)
-		report_openssl_error(errBuffer);
 	if (err != NULL)
 		report_openssl_error(err);
 	if (bio_cert_file != NULL)
@@ -1056,6 +1053,11 @@ openssl_rsa_generate_crl(PG_FUNCTION_ARGS)
 	if (!PG_ARGISNULL(0))
 	{
 		ca_cert_file_path = PG_GETARG_TEXT_PP(0);
+		if (!validate_path_within_datadir(text_to_cstring(ca_cert_file_path)))
+		{
+			err = "PATH_NOT_IN_PGDATA";
+			goto out;
+		}
 
 		/* Get the CA crl */
 		bio_cert_file = BIO_new_file(text_to_cstring(ca_cert_file_path), "r");
@@ -1078,6 +1080,11 @@ openssl_rsa_generate_crl(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(1);
+	if (!validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
+	{
+		err = "PATH_NOT_IN_PGDATA";
+		goto out;
+	}
 
 	/* Get the CA private key */
 	bio_key = BIO_new_file(text_to_cstring(ca_key_file_path), "r");
@@ -1231,6 +1238,12 @@ openssl_is_crt_expire_on(PG_FUNCTION_ARGS)
 	}
 
 	cert_file_path = PG_GETARG_TEXT_PP(0);
+	if (!validate_path_within_datadir(text_to_cstring(cert_file_path)))
+	{
+		err = "PATH_NOT_IN_PGDATA";
+		goto out;
+	}
+
 	fp_cert_file = fopen(text_to_cstring(cert_file_path), "r");
 	if (!fp_cert_file)
 	{
@@ -1650,7 +1663,7 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 	cert_file_path = PG_GETARG_TEXT_PP(0);
 	if (!validate_path_within_datadir(text_to_cstring(cert_file_path)))
 	{
-		err = "PATH_NOT_IN_PGDATA-1";
+		err = "PATH_NOT_IN_PGDATA";
 		goto out;
 	}
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -780,7 +780,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		ca_cert_file_path = PG_GETARG_TEXT_PP(1);
 		if (!validate_path_within_datadir(ca_cert_file_path))
 		{
-			err = "PATH_NOT_IN_PGDATA";
+			err = "PATH_NOT_IN_PGDATA-2";
 			goto out;
 		}
 
@@ -805,9 +805,9 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
-	if (!validate_path_within_datadir(ca_key_file_path))
+	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(ca_key_file_path))
 	{
-		err = "PATH_NOT_IN_PGDATA";
+		err = "PATH_NOT_IN_PGDATA-3";
 		goto out;
 	}
 
@@ -1647,7 +1647,7 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 	cert_file_path = PG_GETARG_TEXT_PP(0);
 	if (!validate_path_within_datadir(cert_file_path))
 	{
-		err = "PATH_NOT_IN_PGDATA";
+		err = "PATH_NOT_IN_PGDATA-1";
 		goto out;
 	}
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -751,6 +751,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	BIO        *bio = NULL;
 	RSA        *ca_key = NULL;
 	char       *err = NULL;
+	char errBuffer[512] = {0};
 	X509_REQ   *req = NULL;
 	X509       *ca_cert = NULL;
 	char       *data = NULL;
@@ -807,7 +808,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
 	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(ca_key_file_path))
 	{
-		sprintf(err, "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, ca_key_file_path);
+		snprintf(errBuffer, sizeof(errBuffer), "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, ca_key_file_path);
 		goto out;
 	}
 
@@ -1015,6 +1016,8 @@ out:
 		X509_EXTENSION_free(extension);
 	if (serial_no != NULL)
 		ASN1_INTEGER_free(serial_no);
+	if (errBuffer[0] != 0)
+		report_openssl_error(errBuffer);
 	if (err != NULL)
 		report_openssl_error(err);
 	if (bio_cert_file != NULL)

--- a/sslutils.c
+++ b/sslutils.c
@@ -149,10 +149,12 @@ static char* string_sep(char **stringp, const char *delim)
 /*
  * This function is to restrict all file access to $PGDATA or a designated subdirectory
  */
-static bool validate_path_within_datadir(const char *path) {
+static bool validate_path_within_datadir(const char *path)
+{
 	char resolved[PATH_MAX], datadir_resolved[PATH_MAX];
 	if (!realpath(path, resolved) || !realpath(DataDir, datadir_resolved))
 		return false;
+
 	return strncmp(resolved, datadir_resolved, strlen(datadir_resolved)) == 0;
 }
 
@@ -186,7 +188,7 @@ static char* make_revocation_str()
 /*
  * This function revoke client certificate and add entry in database file.
  */
-static int revoke(const char* dbfile, X509* x)
+static int revoke_client_certificate(const char* dbfile, X509* x)
 {
 	int i;
 	const ASN1_UTCTIME* tm = NULL;
@@ -1346,7 +1348,7 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 	}
 
 	// First add certificate to database file index.txt which contains list of revoke certificates.
-	ret = revoke(revoke_cert_db_file, x);
+	ret = revoke_client_certificate(revoke_cert_db_file, x);
 	if (ret == -1)
 	{
 		err = "ADD_CERT_TO_DB_FILE";

--- a/sslutils.c
+++ b/sslutils.c
@@ -18,6 +18,7 @@
  */
 
 #include "postgres.h"
+#include "miscadmin.h"
 
 #include <openssl/err.h>
 #include <openssl/pem.h>

--- a/sslutils.c
+++ b/sslutils.c
@@ -778,6 +778,11 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	if (!PG_ARGISNULL(1))
 	{
 		ca_cert_file_path = PG_GETARG_TEXT_PP(1);
+		if (!validate_path_within_datadir(ca_cert_file_path))
+		{
+			err = "PATH_NOT_IN_PGDATA";
+			goto out;
+		}
 
 		/* Get the CA certificate */
 		bio_cert_file = BIO_new_file(text_to_cstring(ca_cert_file_path), "r");
@@ -800,6 +805,11 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
+	if (!validate_path_within_datadir(ca_key_file_path))
+	{
+		err = "PATH_NOT_IN_PGDATA";
+		goto out;
+	}
 
 	/* Get the CA private key */
 	bio_key = BIO_new_file(text_to_cstring(ca_key_file_path), "r");
@@ -1635,6 +1645,12 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 	}
 
 	cert_file_path = PG_GETARG_TEXT_PP(0);
+	if (!validate_path_within_datadir(cert_file_path))
+	{
+		err = "PATH_NOT_IN_PGDATA";
+		goto out;
+	}
+
 	bio_cert_file = BIO_new_file(text_to_cstring(cert_file_path), "r");
 	if (!bio_cert_file)
 	{

--- a/sslutils.c
+++ b/sslutils.c
@@ -779,7 +779,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	if (!PG_ARGISNULL(1))
 	{
 		ca_cert_file_path = PG_GETARG_TEXT_PP(1);
-		if (!validate_path_within_datadir(ca_cert_file_path))
+		if (!validate_path_within_datadir(text_to_cstring(ca_cert_file_path)))
 		{
 			err = "PATH_NOT_IN_PGDATA-2";
 			goto out;
@@ -806,9 +806,9 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
-	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(ca_key_file_path))
+	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
 	{
-		snprintf(errBuffer, sizeof(errBuffer), "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, ca_key_file_path);
+		snprintf(errBuffer, sizeof(errBuffer), "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, text_to_cstring(ca_key_file_path));
 		goto out;
 	}
 
@@ -1648,7 +1648,7 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 	}
 
 	cert_file_path = PG_GETARG_TEXT_PP(0);
-	if (!validate_path_within_datadir(cert_file_path))
+	if (!validate_path_within_datadir(text_to_cstring(cert_file_path)))
 	{
 		err = "PATH_NOT_IN_PGDATA-1";
 		goto out;

--- a/sslutils.c
+++ b/sslutils.c
@@ -146,6 +146,16 @@ static char* string_sep(char **stringp, const char *delim)
 }
 
 /*
+ * This function is to restrict all file access to $PGDATA or a designated subdirectory
+ */
+static bool validate_path_within_datadir(const char *path) {
+	char resolved[PATH_MAX], datadir_resolved[PATH_MAX];
+	if (!realpath(path, resolved) || !realpath(DataDir, datadir_resolved))
+		return false;
+	return strncmp(resolved, datadir_resolved, strlen(datadir_resolved)) == 0;
+}
+
+/*
  * This function make certificate revocation string.
  */
 static char* make_revocation_str()

--- a/sslutils.c
+++ b/sslutils.c
@@ -1442,9 +1442,11 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 		p = line;
 
 		int k = 0;
-		while ((token = string_sep(&p, sep)) != NULL)
+		while ((token = string_sep(&p, sep)) != NULL && k < DB_NUMBER)
 		{
-			strncpy(fields[k++], token, sizeof(fields[0]) - 1);
+			strncpy(fields[k], token, sizeof(fields[0]) - 1);
+			fields[k][sizeof(fields[0]) - 1] = '\0';
+			k++;
 		}
 
 		r = X509_REVOKED_new();

--- a/sslutils.c
+++ b/sslutils.c
@@ -805,7 +805,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
-	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
+	if (!validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
 	{
 		err = "PATH_NOT_IN_PGDATA";
 		goto out;

--- a/sslutils.c
+++ b/sslutils.c
@@ -807,7 +807,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
 	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(ca_key_file_path))
 	{
-		err = "PATH_NOT_IN_PGDATA-3";
+		sprintf(err, "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, ca_key_file_path);
 		goto out;
 	}
 


### PR DESCRIPTION
This PR is to validate the input file path, to be under PGDATA,  for sslutils functions: `openssl_csr_to_crt()`, `openssl_rsa_generate_crl()`, `openssl_is_crt_expire_on()`, `openssl_get_crt_expiry_date()`, to prevent an attacker with SQL EXECUTE privilege on any of these functions can supply a crafted path to read any file accessible to the PostgreSQL OS user (postgres). For details, please check [JIRA](https://enterprisedb.atlassian.net/browse/PEM-6032).

Dev package to test (on RHEL/9/arm64, for EPAS 17): edb-as17-server-sslutils.aarch64-1.4-0.0snapshot25535516447.358.1.4f28abd.1.el9

Test Result:
=== `public.openssl_rsa_generate_crl()` ===
1. File path out of PGDATA is causing error
```
cp /var/lib/edb/as17/data/ca_key.key /mytest/ca_key.key
cp /var/lib/edb/as17/data/ca_certificate.crt /mytest/ca_certificate.crt
PSQLExecuteSuppressLogVoid "SELECT public.openssl_rsa_generate_crl('/mytest/ca_certificate.crt', '/mytest/ca_key.key', 7300);" "pem" "-X -q"ULL, '/mytest/ca_key.key', 3650);" "pem" "-X -q"

ERROR:  OpenSSL error (PATH_NOT_IN_PGDATA): error:00000000:lib(0)::reason(0)
```
2. File path insides PGDATA works
```
ln -sf /var/lib/edb/as17/data/ca_key.key /mytest/ca_key.key
ln -sf /var/lib/edb/as17/data/ca_certificate.crt /mytest/ca_certificate.crt
PSQLExecuteSuppressLogVoid "SELECT public.openssl_rsa_generate_crl('/mytest/ca_certificate.crt', '/mytest/ca_key.key', 7300);" "pem" "-X -q"

-----BEGIN X509 CRL-----
...
-----END X509 CRL-----
```
=== `public.openssl_csr_to_crt()` ===
1. File path out of PGDATA is causing error
```
cp /var/lib/edb/as17/data/server.crt /mytest/server.crt
PSQLExecuteSuppressLogVoid "SELECT public.openssl_get_crt_expiry_date('/mytest/server.crt');" "pem" "-X -q"
PSQLExecuteSuppressLogVoid "SELECT public.openssl_is_crt_expire_on('/mytest/server.crt', '03-MAY-36 02:15:37 +00:00');" "pem" "-X -q"

ERROR:  OpenSSL error (PATH_NOT_IN_PGDATA): error:00000000:lib(0)::reason(0)
ERROR:  OpenSSL error (PATH_NOT_IN_PGDATA): error:00000000:lib(0)::reason(0)
```
2. File path insides PGDATA works
```
CA_KEY=$(cat /var/lib/edb/as17/data/ca_key.key)
ln -sf /var/lib/edb/as17/data/ca_key.key /mytest/ca_key.key
PSQLExecuteSuppressLogVoid "SELECT public.openssl_csr_to_crt(public.openssl_rsa_key_to_csr( \
    '${CA_KEY}', 'PEM', 'US', 'MA', 'Bedford', 'EDB Postgres Enterprise Manager', 'packaging@enterprisedb.com' \
    ), NULL, '/mytest/ca_key.key', 3650);" "pem" "-X -q"

-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
```
=== `public.openssl_get_crt_expiry_date()/public.openssl_is_crt_expire_on()` ===
1. File path out of PGDATA is causing error
```
cp /var/lib/edb/as17/data/server.crt /mytest/server.crt
PSQLExecuteSuppressLogVoid "SELECT public.openssl_get_crt_expiry_date('/mytest/server.crt');" "pem" "-X -q"
PSQLExecuteSuppressLogVoid "SELECT public.openssl_is_crt_expire_on('/mytest/server.crt', '03-MAY-36 02:15:37 +00:00');" "pem" "-X -q"

ERROR:  OpenSSL error (PATH_NOT_IN_PGDATA): error:00000000:lib(0)::reason(0)
ERROR:  OpenSSL error (PATH_NOT_IN_PGDATA): error:00000000:lib(0)::reason(0)
```
2. File path insides PGDATA works
```
ln -sf /var/lib/edb/as17/data/server.crt /mytest/server.crt
PSQLExecuteSuppressLogVoid "SELECT public.openssl_get_crt_expiry_date('/mytest/server.crt');" "pem" "-X -q"
PSQLExecuteSuppressLogVoid "SELECT public.openssl_is_crt_expire_on('/mytest/server.crt', '03-MAY-36 02:15:37 +00:00');" "pem" "-X -q"

05-MAY-36 02:59:18 +00:00
1
```

