### PR TITLE
fix(PEM-6034): Unchecked Return Values Allow Use of Invalid CA Materials

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -147,7 +147,7 @@ static char* string_sep(char **stringp, const char *delim)
 }
 
 /*
- * This function is to restrict all file access to $PGDATA or a designated subdirectory
+ * This function is to restrict all file access to be under $PGDATA
  */
 static bool validate_path_within_datadir(const char *path)
 {
@@ -751,7 +751,6 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	BIO        *bio = NULL;
 	RSA        *ca_key = NULL;
 	char       *err = NULL;
-	char errBuffer[512] = {0};
 	X509_REQ   *req = NULL;
 	X509       *ca_cert = NULL;
 	char       *data = NULL;
@@ -781,7 +780,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		ca_cert_file_path = PG_GETARG_TEXT_PP(1);
 		if (!validate_path_within_datadir(text_to_cstring(ca_cert_file_path)))
 		{
-			err = "PATH_NOT_IN_PGDATA-2";
+			err = "PATH_NOT_IN_PGDATA";
 			goto out;
 		}
 
@@ -808,7 +807,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
 	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
 	{
-		snprintf(errBuffer, sizeof(errBuffer), "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, text_to_cstring(ca_key_file_path));
+		err = "PATH_NOT_IN_PGDATA";
 		goto out;
 	}
 
@@ -1016,8 +1015,6 @@ out:
 		X509_EXTENSION_free(extension);
 	if (serial_no != NULL)
 		ASN1_INTEGER_free(serial_no);
-	if (errBuffer[0] != 0)
-		report_openssl_error(errBuffer);
 	if (err != NULL)
 		report_openssl_error(err);
 	if (bio_cert_file != NULL)
@@ -1056,6 +1053,11 @@ openssl_rsa_generate_crl(PG_FUNCTION_ARGS)
 	if (!PG_ARGISNULL(0))
 	{
 		ca_cert_file_path = PG_GETARG_TEXT_PP(0);
+		if (!validate_path_within_datadir(text_to_cstring(ca_cert_file_path)))
+		{
+			err = "PATH_NOT_IN_PGDATA";
+			goto out;
+		}
 
 		/* Get the CA crl */
 		bio_cert_file = BIO_new_file(text_to_cstring(ca_cert_file_path), "r");
@@ -1078,6 +1080,11 @@ openssl_rsa_generate_crl(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(1);
+	if (!validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
+	{
+		err = "PATH_NOT_IN_PGDATA";
+		goto out;
+	}
 
 	/* Get the CA private key */
 	bio_key = BIO_new_file(text_to_cstring(ca_key_file_path), "r");
@@ -1231,6 +1238,12 @@ openssl_is_crt_expire_on(PG_FUNCTION_ARGS)
 	}
 
 	cert_file_path = PG_GETARG_TEXT_PP(0);
+	if (!validate_path_within_datadir(text_to_cstring(cert_file_path)))
+	{
+		err = "PATH_NOT_IN_PGDATA";
+		goto out;
+	}
+
 	fp_cert_file = fopen(text_to_cstring(cert_file_path), "r");
 	if (!fp_cert_file)
 	{
@@ -1650,7 +1663,7 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 	cert_file_path = PG_GETARG_TEXT_PP(0);
 	if (!validate_path_within_datadir(text_to_cstring(cert_file_path)))
 	{
-		err = "PATH_NOT_IN_PGDATA-1";
+		err = "PATH_NOT_IN_PGDATA";
 		goto out;
 	}
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -780,7 +780,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		ca_cert_file_path = PG_GETARG_TEXT_PP(1);
 		if (!validate_path_within_datadir(ca_cert_file_path))
 		{
-			err = "PATH_NOT_IN_PGDATA";
+			err = "PATH_NOT_IN_PGDATA-2";
 			goto out;
 		}
 
@@ -805,9 +805,9 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
-	if (!validate_path_within_datadir(ca_key_file_path))
+	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(ca_key_file_path))
 	{
-		err = "PATH_NOT_IN_PGDATA";
+		err = "PATH_NOT_IN_PGDATA-3";
 		goto out;
 	}
 
@@ -1647,7 +1647,7 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 	cert_file_path = PG_GETARG_TEXT_PP(0);
 	if (!validate_path_within_datadir(cert_file_path))
 	{
-		err = "PATH_NOT_IN_PGDATA";
+		err = "PATH_NOT_IN_PGDATA-1";
 		goto out;
 	}
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -1416,6 +1416,9 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 	}
 	if (!validate_path_within_allowed_guc(revoke_crl_output_dir, c_crl_filename))
 	{
+		char errBuffer[512] = {0};
+		snprintf (errBuffer, sizeof(errBuffer), "GUC: %s; path: %s\n", revoke_crl_output_dir, c_crl_filename);
+		report_openssl_error(errBuffer);
 		err = "ERROR: CRL file path not in sslutils.revoke_certificate_crl_paths";
 		goto out;
 	}

--- a/sslutils.c
+++ b/sslutils.c
@@ -751,6 +751,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	BIO        *bio = NULL;
 	RSA        *ca_key = NULL;
 	char       *err = NULL;
+	char errBuffer[512] = {0};
 	X509_REQ   *req = NULL;
 	X509       *ca_cert = NULL;
 	char       *data = NULL;
@@ -807,7 +808,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
 	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(ca_key_file_path))
 	{
-		sprintf(err, "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, ca_key_file_path);
+		snprintf(errBuffer, sizeof(errBuffer), "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, ca_key_file_path);
 		goto out;
 	}
 
@@ -1015,6 +1016,8 @@ out:
 		X509_EXTENSION_free(extension);
 	if (serial_no != NULL)
 		ASN1_INTEGER_free(serial_no);
+	if (errBuffer[0] != 0)
+		report_openssl_error(errBuffer);
 	if (err != NULL)
 		report_openssl_error(err);
 	if (bio_cert_file != NULL)

--- a/sslutils.c
+++ b/sslutils.c
@@ -1336,8 +1336,8 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 
 	foreach(l, elemlist)
 	{
-		char* name = (char*) lfirst(l);
-		if (strcmp(name, target) == 0)
+		char* dir = (char*) lfirst(l);
+		if (validate_path_within_dedicated_dir(target, dir))
 		{
 			pfree(rawstring);
 			list_free(elemlist);

--- a/sslutils.c
+++ b/sslutils.c
@@ -32,6 +32,7 @@
 #include "fmgr.h"
 #include "utils/builtins.h"
 #include "utils/datetime.h"
+#include "utils/guc.h"
 #include "utils/varlena.h"
 
 // Start from PG-16, VARDATA_ANY was moved from postgres.h to varatt.h
@@ -150,7 +151,7 @@ static char* string_sep(char **stringp, const char *delim)
 /*
  * This function is to restrict all file access to be under dedicated directory, like PGDATA
  */
-static bool validate_path_within_dedicated_dir(const char *path, dedicated_dir)
+static bool validate_path_within_dedicated_dir(const char *path, char *dedicated_dir)
 {
 	char resolved[PATH_MAX], datadir_resolved[PATH_MAX];
 	if (!realpath(path, resolved) || !realpath(dedicated_dir, datadir_resolved))

--- a/sslutils.c
+++ b/sslutils.c
@@ -1471,7 +1471,11 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 		goto out;
 	}
 
-	PEM_read_bio_X509(bio_ca_cert, &cacert, NULL, NULL);
+	if(!PEM_read_bio_X509(bio_ca_cert, &cacert, NULL, NULL))
+	{
+		err = "FILE_READ_CA_CERT";
+		goto out;
+	}
 	BIO_free(bio_ca_cert);
 	bio_ca_cert = NULL;
 
@@ -1490,7 +1494,11 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 		goto out;
 	}
 
-	PEM_read_bio_PrivateKey(bio_ca_key, &pkey, NULL, NULL);
+	if(!PEM_read_bio_PrivateKey(bio_ca_key, &pkey, NULL, NULL))
+	{
+		err = "ERROR_READ_CA_KEY";
+		goto out;
+	}
 	BIO_free(bio_ca_key);
 	bio_ca_key = NULL;
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -1338,7 +1338,7 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	{
 		char* dir = (char*) lfirst(l);
 		fprintf(stdout, "Comparing %s to %s\n", target, dir);
-		fflush(stdout)
+		fflush(stdout);
 		if (validate_path_within_dedicated_dir(target, dir))
 		{
 			pfree(rawstring);

--- a/sslutils.c
+++ b/sslutils.c
@@ -167,6 +167,7 @@ static char* string_sep(char **stringp, const char *delim)
 
 /*
  * This function is to restrict all file access to be under dedicated directory, like PGDATA
+ * Note: path need be an valid file, otherwise realpath() will return false directly.
  */
 static bool validate_path_within_dedicated_dir(const char *path, char *dedicated_dir)
 {

--- a/sslutils.c
+++ b/sslutils.c
@@ -32,6 +32,7 @@
 #include "fmgr.h"
 #include "utils/builtins.h"
 #include "utils/datetime.h"
+#include "utils/varlena.h"
 
 // Start from PG-16, VARDATA_ANY was moved from postgres.h to varatt.h
 #if PG_VERSION_NUM >= 160000
@@ -147,15 +148,23 @@ static char* string_sep(char **stringp, const char *delim)
 }
 
 /*
- * This function is to restrict all file access to be under $PGDATA
+ * This function is to restrict all file access to be under dedicated directory, like PGDATA
  */
-static bool validate_path_within_datadir(const char *path)
+static bool validate_path_within_dedicated_dir(const char *path, dedicated_dir)
 {
 	char resolved[PATH_MAX], datadir_resolved[PATH_MAX];
-	if (!realpath(path, resolved) || !realpath(DataDir, datadir_resolved))
+	if (!realpath(path, resolved) || !realpath(dedicated_dir, datadir_resolved))
 		return false;
 
 	return strncmp(resolved, datadir_resolved, strlen(datadir_resolved)) == 0;
+}
+
+/*
+ * This function is to restrict all file access to be under PGDATA
+ */
+static bool validate_path_within_datadir(const char *path)
+{
+	return validate_path_within_dedicated_dir(path, DataDir);
 }
 
 /*
@@ -1290,6 +1299,40 @@ out:
 }
 
 /*
+ * This function is to restrict all file access to be under the paths configured in GUC
+ */
+static bool validate_path_within_allowed_guc(char* guc_string, const char* target)
+{
+	char* rawstring;
+	List* elemlist;
+	ListCell* l;
+
+	rawstring = pstrdup(guc_string);
+
+	// It handles case-insensitivity and whitespace automatically
+	if (!SplitIdentifierString(rawstring, ',', &elemlist))
+	{
+		pfree(rawstring);
+		return false;
+	}
+
+	foreach(l, elemlist)
+	{
+		char* name = (char*) lfirst(l);
+		if (strcmp(name, target) == 0)
+		{
+			pfree(rawstring);
+			list_free(elemlist);
+			return true;
+		}
+	}
+
+	pfree(rawstring);
+	list_free(elemlist);
+	return false;
+}
+
+/*
  * Revoke the client certificate and Re-generate CRL.
  */
 Datum
@@ -1346,6 +1389,20 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 	t_crl_filename     = PG_GETARG_TEXT_PP(1);
 
 	c_crl_filename  = text_to_cstring(t_crl_filename);
+
+	// To be safe, the CRL file need be under the paths configured in sslutils.revoke_certificate.crl_paths
+	const char* allowed_paths = GetConfigOptionByName("sslutils.revoke_certificate.crl_paths", NULL, false);
+	if (!allowed_paths)
+	{
+		err = "ERROR: sslutils.revoke_certificate.crl_paths not configured";
+		goto out;
+	}
+	if (!validate_path_within_allowed_guc(allowed_paths, c_crl_filename))
+	{
+		err = "ERROR: CRL file path not in sslutils.revoke_certificate.crl_paths";
+		goto out;
+	}
+
 	crl_file_len = strlen(c_crl_filename);
 
 	cert_data_size = strlen(text_to_cstring(cert_t_data)) + 1;

--- a/sslutils.c
+++ b/sslutils.c
@@ -149,10 +149,12 @@ static char* string_sep(char **stringp, const char *delim)
 /*
  * This function is to restrict all file access to $PGDATA or a designated subdirectory
  */
-static bool validate_path_within_datadir(const char *path) {
+static bool validate_path_within_datadir(const char *path)
+{
 	char resolved[PATH_MAX], datadir_resolved[PATH_MAX];
 	if (!realpath(path, resolved) || !realpath(DataDir, datadir_resolved))
 		return false;
+
 	return strncmp(resolved, datadir_resolved, strlen(datadir_resolved)) == 0;
 }
 
@@ -186,7 +188,7 @@ static char* make_revocation_str()
 /*
  * This function revoke client certificate and add entry in database file.
  */
-static int revoke(const char* dbfile, X509* x)
+static int revoke_client_certificate(const char* dbfile, X509* x)
 {
 	int i;
 	const ASN1_UTCTIME* tm = NULL;
@@ -1346,7 +1348,7 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 	}
 
 	// First add certificate to database file index.txt which contains list of revoke certificates.
-	ret = revoke(revoke_cert_db_file, x);
+	ret = revoke_client_certificate(revoke_cert_db_file, x);
 	if (ret == -1)
 	{
 		err = "ADD_CERT_TO_DB_FILE";

--- a/sslutils.c
+++ b/sslutils.c
@@ -18,6 +18,7 @@
  */
 
 #include "postgres.h"
+#include "miscadmin.h"
 
 #include <openssl/err.h>
 #include <openssl/pem.h>

--- a/sslutils.c
+++ b/sslutils.c
@@ -126,7 +126,7 @@ void
 _PG_init(void)
 {
 	DefineCustomStringVariable(
-		"sslutils.revoke_certificate.crl_paths",	// Parameter name
+		"sslutils.revoke_certificate_crl_paths",	// Parameter name
 		"Directory to store allowed revoke CRL dirs.",	// Short description
 		NULL,						// Long description
 		&revoke_crl_output_dir,				// Pointer to our C-string
@@ -1408,15 +1408,15 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 
 	c_crl_filename  = text_to_cstring(t_crl_filename);
 
-	// To be safe, the CRL file need be under the paths configured in sslutils.revoke_certificate.crl_paths
+	// To be safe, the CRL file need be under the paths configured in sslutils.revoke_certificate_crl_paths
 	if (!revoke_crl_output_dir)
 	{
-		err = "ERROR: sslutils.revoke_certificate.crl_paths not configured";
+		err = "ERROR: sslutils.revoke_certificate_crl_paths not configured";
 		goto out;
 	}
 	if (!validate_path_within_allowed_guc(revoke_crl_output_dir, c_crl_filename))
 	{
-		err = "ERROR: CRL file path not in sslutils.revoke_certificate.crl_paths";
+		err = "ERROR: CRL file path not in sslutils.revoke_certificate_crl_paths";
 		goto out;
 	}
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -174,6 +174,8 @@ static bool validate_path_within_dedicated_dir(const char *path, char *dedicated
 	if (!realpath(path, resolved) || !realpath(dedicated_dir, datadir_resolved))
 		return false;
 
+	fprintf(stdout, "Validating %s to %s\n", resolved, datadir_resolved);
+	fflush(stdout);
 	return strncmp(resolved, datadir_resolved, strlen(datadir_resolved)) == 0;
 }
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -174,8 +174,6 @@ static bool validate_path_within_dedicated_dir(const char *path, char *dedicated
 	if (!realpath(path, resolved) || !realpath(dedicated_dir, datadir_resolved))
 		return false;
 
-	fprintf(stdout, "Validating %s to %s\n", resolved, datadir_resolved);
-	fflush(stdout);
 	return strncmp(resolved, datadir_resolved, strlen(datadir_resolved)) == 0;
 }
 
@@ -1339,9 +1337,7 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	foreach(l, elemlist)
 	{
 		char* dir = (char*) lfirst(l);
-		fprintf(stdout, "Comparing %s to %s\n", target, dir);
-		fflush(stdout);
-		if (validate_path_within_dedicated_dir(target, dir))
+		if (strncmp(target, dir, strlen(dir)) == 0)
 		{
 			pfree(rawstring);
 			list_free(elemlist);
@@ -1420,9 +1416,6 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 	}
 	if (!validate_path_within_allowed_guc(revoke_crl_output_dir, c_crl_filename))
 	{
-		char errBuffer[512] = {0};
-		snprintf (errBuffer, sizeof(errBuffer), "GUC: %s; path: %s\n", revoke_crl_output_dir, c_crl_filename);
-		report_openssl_error(errBuffer);
 		err = "ERROR: CRL file path not in sslutils.revoke_certificate_crl_paths";
 		goto out;
 	}

--- a/sslutils.c
+++ b/sslutils.c
@@ -1337,6 +1337,8 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	foreach(l, elemlist)
 	{
 		char* dir = (char*) lfirst(l);
+		fprintf(stdout, "Comparing %s to %s\n", target, dir);
+		fflush(stdout)
 		if (validate_path_within_dedicated_dir(target, dir))
 		{
 			pfree(rawstring);

--- a/sslutils.c
+++ b/sslutils.c
@@ -116,10 +116,27 @@ time_t ASN1_GetTimeT(const ASN1_TIME* time);
 
 #define PEM_SSLUTILS_VERSION "1.4"
 
+/*
+ * Global variable to hold the path of allowed revoke CRL directory
+ */
+static char* revoke_crl_output_dir = NULL;
+
 /* On module load, make sure SSL error strings are available. */
 void
 _PG_init(void)
 {
+	DefineCustomStringVariable(
+		"sslutils.revoke_certificate.crl_paths",	// Parameter name
+		"Directory to store allowed revoke CRL dirs.",	// Short description
+		NULL,						// Long description
+		&revoke_crl_output_dir,				// Pointer to our C-string
+		NULL,						// Default value
+		PGC_SIGHUP,					// Context (requires reload to change)
+		0,						// Flags
+		NULL,						// Check hook
+		NULL,						// Assign hook
+		NULL						// Show hook
+	);
 }
 
 /* Report an error within OpenSSL. */
@@ -1392,13 +1409,12 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 	c_crl_filename  = text_to_cstring(t_crl_filename);
 
 	// To be safe, the CRL file need be under the paths configured in sslutils.revoke_certificate.crl_paths
-	const char* allowed_paths = GetConfigOptionByName("sslutils.revoke_certificate.crl_paths", NULL, false);
-	if (!allowed_paths)
+	if (!revoke_crl_output_dir)
 	{
 		err = "ERROR: sslutils.revoke_certificate.crl_paths not configured";
 		goto out;
 	}
-	if (!validate_path_within_allowed_guc(allowed_paths, c_crl_filename))
+	if (!validate_path_within_allowed_guc(revoke_crl_output_dir, c_crl_filename))
 	{
 		err = "ERROR: CRL file path not in sslutils.revoke_certificate.crl_paths";
 		goto out;

--- a/sslutils.c
+++ b/sslutils.c
@@ -778,6 +778,11 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	if (!PG_ARGISNULL(1))
 	{
 		ca_cert_file_path = PG_GETARG_TEXT_PP(1);
+		if (!validate_path_within_datadir(ca_cert_file_path))
+		{
+			err = "PATH_NOT_IN_PGDATA";
+			goto out;
+		}
 
 		/* Get the CA certificate */
 		bio_cert_file = BIO_new_file(text_to_cstring(ca_cert_file_path), "r");
@@ -800,6 +805,11 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
+	if (!validate_path_within_datadir(ca_key_file_path))
+	{
+		err = "PATH_NOT_IN_PGDATA";
+		goto out;
+	}
 
 	/* Get the CA private key */
 	bio_key = BIO_new_file(text_to_cstring(ca_key_file_path), "r");
@@ -1635,6 +1645,12 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 	}
 
 	cert_file_path = PG_GETARG_TEXT_PP(0);
+	if (!validate_path_within_datadir(cert_file_path))
+	{
+		err = "PATH_NOT_IN_PGDATA";
+		goto out;
+	}
+
 	bio_cert_file = BIO_new_file(text_to_cstring(cert_file_path), "r");
 	if (!bio_cert_file)
 	{

--- a/sslutils.c
+++ b/sslutils.c
@@ -779,7 +779,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	if (!PG_ARGISNULL(1))
 	{
 		ca_cert_file_path = PG_GETARG_TEXT_PP(1);
-		if (!validate_path_within_datadir(ca_cert_file_path))
+		if (!validate_path_within_datadir(text_to_cstring(ca_cert_file_path)))
 		{
 			err = "PATH_NOT_IN_PGDATA-2";
 			goto out;
@@ -806,9 +806,9 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
-	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(ca_key_file_path))
+	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
 	{
-		snprintf(errBuffer, sizeof(errBuffer), "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, ca_key_file_path);
+		snprintf(errBuffer, sizeof(errBuffer), "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, text_to_cstring(ca_key_file_path));
 		goto out;
 	}
 
@@ -1648,7 +1648,7 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 	}
 
 	cert_file_path = PG_GETARG_TEXT_PP(0);
-	if (!validate_path_within_datadir(cert_file_path))
+	if (!validate_path_within_datadir(text_to_cstring(cert_file_path)))
 	{
 		err = "PATH_NOT_IN_PGDATA-1";
 		goto out;

--- a/sslutils.c
+++ b/sslutils.c
@@ -146,6 +146,16 @@ static char* string_sep(char **stringp, const char *delim)
 }
 
 /*
+ * This function is to restrict all file access to $PGDATA or a designated subdirectory
+ */
+static bool validate_path_within_datadir(const char *path) {
+	char resolved[PATH_MAX], datadir_resolved[PATH_MAX];
+	if (!realpath(path, resolved) || !realpath(DataDir, datadir_resolved))
+		return false;
+	return strncmp(resolved, datadir_resolved, strlen(datadir_resolved)) == 0;
+}
+
+/*
  * This function make certificate revocation string.
  */
 static char* make_revocation_str()

--- a/sslutils.c
+++ b/sslutils.c
@@ -1442,9 +1442,11 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 		p = line;
 
 		int k = 0;
-		while ((token = string_sep(&p, sep)) != NULL)
+		while ((token = string_sep(&p, sep)) != NULL && k < DB_NUMBER)
 		{
-			strncpy(fields[k++], token, sizeof(fields[0]) - 1);
+			strncpy(fields[k], token, sizeof(fields[0]) - 1);
+			fields[k][sizeof(fields[0]) - 1] = '\0';
+			k++;
 		}
 
 		r = X509_REVOKED_new();

--- a/sslutils.c
+++ b/sslutils.c
@@ -805,7 +805,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
-	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
+	if (!validate_path_within_datadir(text_to_cstring(ca_key_file_path)))
 	{
 		err = "PATH_NOT_IN_PGDATA";
 		goto out;

--- a/sslutils.c
+++ b/sslutils.c
@@ -807,7 +807,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	ca_key_file_path = PG_GETARG_TEXT_PP(2);
 	if (!PG_ARGISNULL(2) && !validate_path_within_datadir(ca_key_file_path))
 	{
-		err = "PATH_NOT_IN_PGDATA-3";
+		sprintf(err, "PATH_NOT_IN_PGDATA-3: - DataDir: %s - path: %s", DataDir, ca_key_file_path);
 		goto out;
 	}
 


### PR DESCRIPTION
Regarding the 3 issues reported in JIRA:
1. F6 — NULL Pointer Dereference in CRL Generation
CWE-476 | sslutils.c:1093, 1391
```
When ca_cert is NULL, X509_NAME_dup(NULL) returns NULL. Passing NULL to X509_CRL_set_issuer_name either causes a segfault (crash) or produces a CRL with no issuer field — a fail-open condition where an invalid CRL is silently accepted.
```
Actually ca_cert won't be NULL, because we already checked the value on:
https://github.com/EnterpriseDB/sslutils/blob/v1.4-1/sslutils.c#L1042
https://github.com/EnterpriseDB/sslutils/blob/v1.4-1/sslutils.c#L1347

2. F7 — Unchecked Return Values Allow Use of Invalid CA Materials
Fixed in this PR

3. F14 — TOCTOU Race Condition in Revocation Database
CWE-367 | sslutils.c:208–273
```
The revoke() function opens the revocation database file, reads it to check for duplicates, then writes a new entry — with no file locking between read and write
```
I think this concern is not necessary, because this function is only called once every few years, when the certificate is about to expire.