### PR TITLE
fix(PEM-6038): Incorrect memset Size Leaves 128 Bytes Uninitialised in Field Array

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -1552,7 +1552,9 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 		if (line[0] != 'R')
 			continue;
 
-		memset(fields, 0, 256);
+		fprintf(stdout, "size of fields: %d\n", sizeof(fields));
+		fflush(stdout);
+		memset(fields, 0, sizeof(fields));
 		p = line;
 
 		int k = 0;

--- a/sslutils.c
+++ b/sslutils.c
@@ -1552,8 +1552,6 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 		if (line[0] != 'R')
 			continue;
 
-		fprintf(stdout, "size of fields: %d\n", sizeof(fields));
-		fflush(stdout);
 		memset(fields, 0, sizeof(fields));
 		p = line;
 


### PR DESCRIPTION
The size of field arrary is `6*64=384`, not `256`, it is a typo need to fix.