### PR TITLE
fix(PEM-6039): using BN_rand() to replace deprecated BN_pseudo_rand()

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -52,7 +52,7 @@
 #define X509_CRL_set1_lastUpdate X509_CRL_set_lastUpdate
 #endif // if OPENSSL_VERSION_NUMBER < 0x10100000L
 
-#define SERIAL_RAND_BITS  64
+#define SERIAL_RAND_BITS  159
 #define DEDAULT_VALIDITY_DAYS  3650
 
 #define BUFFER_PADDING_BYTES 50
@@ -951,7 +951,7 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 
-	if (!BN_pseudo_rand(bn, SERIAL_RAND_BITS, 0, 0))
+	if (!BN_rand(bn, SERIAL_RAND_BITS, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY))
 	{
 		err = "Error_generating_random_bignum";
 		goto out;


### PR DESCRIPTION
As per JIRA: `Certificate serial numbers are generated using BN_pseudo_rand() with only 64 bits of entropy. BN_pseudo_rand is not cryptographically secure, violates RFC 5280 (which recommends ≥160 bits)`

This PR is to use `BN_rand()` to replace `BN_pseudo_rand()`, and using 160 bits of entropy.

The dev build for PG 17: https://github.com/EnterpriseDB/sslutils-packaging/actions/runs/26263072692
The dev build for EPAS 17: https://github.com/EnterpriseDB/sslutils-packaging/actions/runs/26262925822

Smoke test of PG-17 sslutils with PEM: https://github.com/EnterpriseDB/pem-package-regression/actions/runs/26263660511
Smoke test of EPAS-17 sslutils with PEM: https://github.com/EnterpriseDB/pem-package-regression/actions/runs/26263611933

