### PR TITLE
fix: Race Condition in Revocation Database

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -20,6 +20,7 @@
 #include "postgres.h"
 #include "miscadmin.h"
 #include "unistd.h"
+#include <sys/file.h>
 
 #include <openssl/err.h>
 #include <openssl/pem.h>

--- a/sslutils.c
+++ b/sslutils.c
@@ -19,6 +19,7 @@
 
 #include "postgres.h"
 #include "miscadmin.h"
+#include "unistd.h"
 
 #include <openssl/err.h>
 #include <openssl/pem.h>
@@ -250,6 +251,14 @@ static int revoke_client_certificate(const char* dbfile, X509* x)
 	if (revoke_file == NULL)
 		return -1;
 
+	if (flock(fileno(revoke_file), LOCK_EX) != 0)
+	{
+		fprintf(stdout, "Could not lock revocation database, maybe it is locked by another process.\n");
+		fflush(stdout);
+		ereport(ERROR, (errmsg("Could not lock revocation database")));
+		return -1;
+	}
+
 	// Lookup whether the client cert has been revoke by serial number
 	// and rotate the index.txt
 	while (fgets(line, 512, revoke_file))
@@ -311,6 +320,8 @@ static int revoke_client_certificate(const char* dbfile, X509* x)
 	}
 	fwrite("\n", 1, 1, revoke_file);
 
+	// For testing purpose
+	sleep(10);
 	fclose(revoke_file);
 	return 0;
 }

--- a/sslutils.c
+++ b/sslutils.c
@@ -252,11 +252,19 @@ static int revoke_client_certificate(const char* dbfile, X509* x)
 	if (revoke_file == NULL)
 		return -1;
 
-	if (flock(fileno(revoke_file), LOCK_EX) != 0)
+	if (flock(fileno(revoke_file), LOCK_EX | LOCK_NB) != 0)
 	{
-		fprintf(stdout, "Could not lock revocation database, maybe it is locked by another process.\n");
-		fflush(stdout);
-		ereport(ERROR, (errmsg("Could not lock revocation database")));
+		if (errno == EWOULDBLOCK) {
+			fprintf(stdout, "Could not lock revocation database, it is already locked by another process.\n");
+			fflush(stdout);
+			ereport(ERROR, (errmsg("Could not lock revocation database, it is already locked by another process ---")));
+		}
+		else
+		{
+			fprintf(stdout, "Could not lock revocation database, for unknown reason.\n");
+			fflush(stdout);
+			ereport(ERROR, (errmsg("Could not lock revocation database, for unknown reason ---")));
+		}
 		return -1;
 	}
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -19,7 +19,6 @@
 
 #include "postgres.h"
 #include "miscadmin.h"
-#include "unistd.h"
 #include <sys/file.h>
 
 #include <openssl/err.h>
@@ -255,15 +254,7 @@ static int revoke_client_certificate(const char* dbfile, X509* x)
 	if (flock(fileno(revoke_file), LOCK_EX | LOCK_NB) != 0)
 	{
 		if (errno == EWOULDBLOCK) {
-			fprintf(stdout, "Could not lock revocation database, it is already locked by another process.\n");
-			fflush(stdout);
-			ereport(ERROR, (errmsg("Could not lock revocation database, it is already locked by another process ---")));
-		}
-		else
-		{
-			fprintf(stdout, "Could not lock revocation database, for unknown reason.\n");
-			fflush(stdout);
-			ereport(ERROR, (errmsg("Could not lock revocation database, for unknown reason ---")));
+			ereport(ERROR, (errmsg("Could not lock revocation database, it is already locked by another process.")));
 		}
 		return -1;
 	}
@@ -329,8 +320,6 @@ static int revoke_client_certificate(const char* dbfile, X509* x)
 	}
 	fwrite("\n", 1, 1, revoke_file);
 
-	// For testing purpose
-	sleep(10);
 	fclose(revoke_file);
 	return 0;
 }


### PR DESCRIPTION
This PR is to fix an potential issue that two concurrent PostgreSQL backends calling revoke() simultaneously can:
* Both pass the duplicate check (neither sees the other's entry yet)
* Both write their entries — resulting in duplicate revocation entries
* Or interleave writes, corrupting the database file

The change is to use `flock()` to lock the file description, when another process calls revoke() and the previous process is not done yet, the second process would return error like below:
```
ERROR:  Could not lock revocation database, it is already locked by another process.
```