### PR TITLE
fix(PEM-6044): Double Free of comp_time in unpack_revinfo() Causes Heap Corruption

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -446,7 +446,10 @@ static int unpack_revinfo(ASN1_TIME** prevtm, int* preason, ASN1_OBJECT** phold,
 	if (pinvtm)
 		*pinvtm = comp_time;
 	else
+	{
 		ASN1_GENERALIZEDTIME_free(comp_time);
+		comp_time = NULL;
+	}
 
 	ret = 1;
 
@@ -455,8 +458,11 @@ static int unpack_revinfo(ASN1_TIME** prevtm, int* preason, ASN1_OBJECT** phold,
 		OPENSSL_free(tmp);
 	if (!phold)
 		ASN1_OBJECT_free(hold);
-	if (!pinvtm)
+	if (comp_time)
+	{
 		ASN1_GENERALIZEDTIME_free(comp_time);
+		comp_time = NULL;
+	}
 	if (errBuffer[0] != 0)
 		report_openssl_error(errBuffer);
 


### PR DESCRIPTION
Please check [JIRA](https://enterprisedb.atlassian.net/browse/PEM-6044) for details.

The fix is straightforward, to check if the value: `comp_time` is `NULL` before freeing it, and set it to `NULL` after freeing it.