### PR TITLE
fix(PEM-6043): Out-of-Bounds Read in ASN1_GetTimeT — Malformed Certificate Causes Memory Corruption

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -1697,6 +1697,43 @@ out:
 time_t
 ASN1_GetTimeT(const ASN1_TIME* time)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	struct tm t;
+	const char* str = (const char*)time->data;
+	size_t i = 0;
+
+	memset(&t, 0, sizeof(t));
+
+	if (time->type == V_ASN1_UTCTIME) {/* two digit year */
+		t.tm_year = (str[i++] - '0') * 10;
+		t.tm_year += (str[i++] - '0');
+		if (t.tm_year < 70)
+			t.tm_year += 100;
+	}
+	else if (time->type == V_ASN1_GENERALIZEDTIME) {/* four digit year */
+		t.tm_year = (str[i++] - '0') * 1000;
+		t.tm_year += (str[i++] - '0') * 100;
+		t.tm_year += (str[i++] - '0') * 10;
+		t.tm_year += (str[i++] - '0');
+		t.tm_year -= 1900;
+	}
+
+	t.tm_mon = (str[i++] - '0') * 10;
+	t.tm_mon += (str[i++] - '0') - 1; // -1 since January is 0 not 1.
+	t.tm_mday = (str[i++] - '0') * 10;
+	t.tm_mday += (str[i++] - '0');
+	t.tm_hour = (str[i++] - '0') * 10;
+	t.tm_hour += (str[i++] - '0');
+	t.tm_min = (str[i++] - '0') * 10;
+	t.tm_min += (str[i++] - '0');
+	t.tm_sec = (str[i++] - '0') * 10;
+	t.tm_sec += (str[i++] - '0');
+
+	/* Note: we did not adjust the time based on time zone information */
+	return mktime(&t);
+#else
+#error "For testing purpose, to see which platforms has OpenSSL >= 1.1.0"
+	// ASN1_TIME_to_tm() is a safe API but available OpenSSL 1.1.0
 	struct tm t;
 	memset(&t, 0, sizeof(t));
 
@@ -1704,6 +1741,7 @@ ASN1_GetTimeT(const ASN1_TIME* time)
 		return (time_t)-1;   // error: malformed time field
 
 	return timegm(&t);
+#endif // if OPENSSL_VERSION_NUMBER < 0x10100000L
 }
 
 /*

--- a/sslutils.c
+++ b/sslutils.c
@@ -1732,7 +1732,6 @@ ASN1_GetTimeT(const ASN1_TIME* time)
 	/* Note: we did not adjust the time based on time zone information */
 	return mktime(&t);
 #else
-#error "For testing purpose, to see which platforms has OpenSSL >= 1.1.0"
 	// ASN1_TIME_to_tm() is a safe API but available OpenSSL 1.1.0
 	struct tm t;
 	memset(&t, 0, sizeof(t));

--- a/sslutils.c
+++ b/sslutils.c
@@ -1691,44 +1691,19 @@ out:
 
 /*
 * Convert ASN1_TIME to tm.
+*  -- Using the OpenSSL (like ASN1_TIME_to_tm which is vailable since OpenSSL 1.1.0)
 *
 */
 time_t
 ASN1_GetTimeT(const ASN1_TIME* time)
 {
 	struct tm t;
-	const char* str = (const char*)time->data;
-	size_t i = 0;
-
 	memset(&t, 0, sizeof(t));
 
-	if (time->type == V_ASN1_UTCTIME) {/* two digit year */
-		t.tm_year = (str[i++] - '0') * 10;
-		t.tm_year += (str[i++] - '0');
-		if (t.tm_year < 70)
-			t.tm_year += 100;
-	}
-	else if (time->type == V_ASN1_GENERALIZEDTIME) {/* four digit year */
-		t.tm_year = (str[i++] - '0') * 1000;
-		t.tm_year += (str[i++] - '0') * 100;
-		t.tm_year += (str[i++] - '0') * 10;
-		t.tm_year += (str[i++] - '0');
-		t.tm_year -= 1900;
-	}
+	if (!ASN1_TIME_to_tm(time, &t))
+		return (time_t)-1;   // error: malformed time field
 
-	t.tm_mon = (str[i++] - '0') * 10;
-	t.tm_mon += (str[i++] - '0') - 1; // -1 since January is 0 not 1.
-	t.tm_mday = (str[i++] - '0') * 10;
-	t.tm_mday += (str[i++] - '0');
-	t.tm_hour = (str[i++] - '0') * 10;
-	t.tm_hour += (str[i++] - '0');
-	t.tm_min = (str[i++] - '0') * 10;
-	t.tm_min += (str[i++] - '0');
-	t.tm_sec = (str[i++] - '0') * 10;
-	t.tm_sec += (str[i++] - '0');
-
-	/* Note: we did not adjust the time based on time zone information */
-	return mktime(&t);
+	return timegm(&t);
 }
 
 /*

--- a/sslutils.c
+++ b/sslutils.c
@@ -1691,7 +1691,6 @@ out:
 
 /*
 * Convert ASN1_TIME to tm.
-*  -- Using the OpenSSL (like ASN1_TIME_to_tm which is vailable since OpenSSL 1.1.0)
 *
 */
 time_t
@@ -1732,7 +1731,7 @@ ASN1_GetTimeT(const ASN1_TIME* time)
 	/* Note: we did not adjust the time based on time zone information */
 	return mktime(&t);
 #else
-	// ASN1_TIME_to_tm() is a safe API but available OpenSSL 1.1.0
+	// ASN1_TIME_to_tm() is a safe API but available since OpenSSL 1.1.0
 	struct tm t;
 	memset(&t, 0, sizeof(t));
 


### PR DESCRIPTION
This PR is to rewrite function: `ASN1_GetTimeT` with OpenSSL's safe API, for the platforms has OpenSSL > 1.1.0 since the new API is available starts from OpenSSL 1.1.0.

Verified on RHEL/9/arm64 with package version: `1.4-0.0snapshot26390829750.369.2.0a12e92.1.el9`
```
PSQLExecuteSuppressLogVoid "SELECT public.openssl_get_crt_expiry_date('${PG_DATA_DIR}/server.crt');" "pem" "-X -q"

20-MAY-46 10:10:12 +00:00
```
