### PR TITLE
fix(PEM-6056): pem_agent GRANT bypasses pg_read_server_files / pg_write_server_files

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -205,7 +205,7 @@ static bool validate_path_within_datadir(const char *path)
 }
 
 /*
- * On PostgreSQL 15+, file access from SQL is gated by the pg_read_server_files and pg_write_server_files roles.
+ * On PostgreSQL 11+, file access from SQL is gated by the pg_read_server_files and pg_write_server_files roles.
  * This function is to check if the user has the permisson of pg_read_server_files.
  */
 static void check_read_server_file_permission()

--- a/sslutils.c
+++ b/sslutils.c
@@ -199,7 +199,7 @@ static bool check_read_server_file_permission()
 		ereport(ERROR,
 			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 			errmsg("must be a member of pg_read_server_files to use this function")));
-		retrun false;
+		return false;
 	}
 	return true;
 #endif
@@ -216,7 +216,7 @@ static bool check_write_server_file_permission()
 		ereport(ERROR,
 			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 			errmsg("must be a member of pg_write_server_files to use this function")));
-		retrun false;
+		return false;
 	}
 	return true;
 #endif

--- a/sslutils.c
+++ b/sslutils.c
@@ -41,6 +41,23 @@
 #include "varatt.h"
 #endif
 
+// To call functions like is_member_of_role()
+#if PG_VERSION_NUM >= 110000
+#include "utils/errcodes.h"
+#include "utils/acl.h"
+#include "catalog/pg_authid.h"
+
+// Compatibility layer for PostgreSQL < 14
+#if PG_VERSION_NUM < 140000 && defined(DEFAULT_ROLE_READ_SERVER_FILES)
+#define ROLE_PG_READ_SERVER_FILES DEFAULT_ROLE_READ_SERVER_FILES
+#endif
+#if PG_VERSION_NUM < 140000 && defined(DEFAULT_ROLE_WRITE_SERVER_FILES)
+#define ROLE_PG_WRITE_SERVER_FILES DEFAULT_ROLE_WRITE_SERVER_FILES
+#endif
+
+#endif
+
+
 /*
  * For compatibility with OpenSSL 1.0.2
  *
@@ -194,7 +211,7 @@ static bool validate_path_within_datadir(const char *path)
 static bool check_read_server_file_permission()
 {
 #if PG_VERSION_NUM >= 110000
-	if (!is_member_of_role(GetUserId(), DEFAULT_ROLE_READ_SERVER_FILES))
+	if (!is_member_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
 	{
 		ereport(ERROR,
 			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
@@ -211,7 +228,7 @@ static bool check_read_server_file_permission()
 static bool check_write_server_file_permission()
 {
 #if PG_VERSION_NUM >= 110000
-	if (!is_member_of_role(GetUserId(), DEFAULT_ROLE_WRITE_SERVER_FILES))
+	if (!is_member_of_role(GetUserId(), ROLE_PG_WRITE_SERVER_FILES))
 	{
 		ereport(ERROR,
 			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/sslutils.c
+++ b/sslutils.c
@@ -1468,6 +1468,7 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 	ASN1_INTEGER *tmpser = NULL;
 	int retVal = 0;
 
+	check_read_server_file_permission();
 	check_write_server_file_permission();
 
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))

--- a/sslutils.c
+++ b/sslutils.c
@@ -208,7 +208,7 @@ static bool validate_path_within_datadir(const char *path)
  * On PostgreSQL 15+, file access from SQL is gated by the pg_read_server_files and pg_write_server_files roles.
  * This function is to check if the user has the permisson of pg_read_server_files.
  */
-static bool check_read_server_file_permission()
+static void check_read_server_file_permission()
 {
 #if PG_VERSION_NUM >= 110000
 	if (!is_member_of_role(GetUserId(), ROLE_PG_READ_SERVER_FILES))
@@ -216,9 +216,7 @@ static bool check_read_server_file_permission()
 		ereport(ERROR,
 			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 			errmsg("must be a member of pg_read_server_files to use this function")));
-		return false;
 	}
-	return true;
 #endif
 }
 
@@ -233,9 +231,7 @@ static bool check_write_server_file_permission()
 		ereport(ERROR,
 			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 			errmsg("must be a member of pg_write_server_files to use this function")));
-		return false;
 	}
-	return true;
 #endif
 }
 
@@ -880,6 +876,8 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 			goto out;
 		}
 
+		check_read_server_file_permission();
+
 		/* Get the CA certificate */
 		bio_cert_file = BIO_new_file(text_to_cstring(ca_cert_file_path), "r");
 		if (!bio_cert_file)
@@ -1155,6 +1153,8 @@ openssl_rsa_generate_crl(PG_FUNCTION_ARGS)
 			goto out;
 		}
 
+		check_read_server_file_permission();
+
 		/* Get the CA crl */
 		bio_cert_file = BIO_new_file(text_to_cstring(ca_cert_file_path), "r");
 		if (!bio_cert_file)
@@ -1340,6 +1340,8 @@ openssl_is_crt_expire_on(PG_FUNCTION_ARGS)
 		goto out;
 	}
 
+	check_read_server_file_permission();
+
 	fp_cert_file = fopen(text_to_cstring(cert_file_path), "r");
 	if (!fp_cert_file)
 	{
@@ -1465,6 +1467,8 @@ openssl_revoke_certificate(PG_FUNCTION_ARGS)
 	X509_REVOKED *r = NULL;
 	ASN1_INTEGER *tmpser = NULL;
 	int retVal = 0;
+
+	check_write_server_file_permission();
 
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
 	{
@@ -1829,13 +1833,7 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 		goto out;
 	}
 
-	if (!check_read_server_file_permission())
-	{
-		fprintf(stdout, "Missing pg_read_server_files permisson!\n");
-		fflush(stdout);
-		err = "Missing pg_read_server_files permisson";
-		goto out;
-	}
+	check_read_server_file_permission();
 
 	bio_cert_file = BIO_new_file(text_to_cstring(cert_file_path), "r");
 	if (!bio_cert_file)

--- a/sslutils.c
+++ b/sslutils.c
@@ -188,6 +188,42 @@ static bool validate_path_within_datadir(const char *path)
 }
 
 /*
+ * On PostgreSQL 15+, file access from SQL is gated by the pg_read_server_files and pg_write_server_files roles.
+ * This function is to check if the user has the permisson of pg_read_server_files.
+ */
+static bool check_read_server_file_permission()
+{
+#if PG_VERSION_NUM >= 110000
+	if (!is_member_of_role(GetUserId(), DEFAULT_ROLE_READ_SERVER_FILES))
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+			errmsg("must be a member of pg_read_server_files to use this function")));
+		retrun false;
+	}
+	return true;
+#endif
+}
+
+/*
+ * This function is to check if the user has the permisson of pg_write_server_files.
+ */
+static bool check_write_server_file_permission()
+{
+#if PG_VERSION_NUM >= 110000
+	if (!is_member_of_role(GetUserId(), DEFAULT_ROLE_WRITE_SERVER_FILES))
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+			errmsg("must be a member of pg_write_server_files to use this function")));
+		retrun false;
+	}
+	return true;
+#endif
+}
+
+/*
+/*
  * This function make certificate revocation string.
  */
 static char* make_revocation_str()
@@ -1773,6 +1809,14 @@ openssl_get_crt_expiry_date(PG_FUNCTION_ARGS)
 	if (!validate_path_within_datadir(text_to_cstring(cert_file_path)))
 	{
 		err = "PATH_NOT_IN_PGDATA";
+		goto out;
+	}
+
+	if (!check_read_server_file_permission())
+	{
+		fprintf(stdout, "Missing pg_read_server_files permisson!\n");
+		fflush(stdout);
+		err = "Missing pg_read_server_files permisson";
 		goto out;
 	}
 


### PR DESCRIPTION
This PR is to enforce the rules:
1. pem_agent members without `pg_read_server_files` cannot read arbitrary files via any sslutils function.
2. pem_agent members without `pg_write_server_files` cannot write arbitrary files via any sslutils function.

The roles: `pg_read_server_files/pg_write_server_files` are introduced since PG 11, as per the design, to allow administrators to grant a user the specific ability to read/write local server files without handing them full, unrestricted superuser privileges. The sslutils functions were bypassing these roles.

Currently there are 2 scenarios calling the sslutils functions: (please let me know if I missed something)
1. The `superuser` is generating certificates during PEM configuration
2. The `pem_agent` user is checking and regenerating certificate on the job of `Check CA certificate expiry`

The 2nd scenario would be impacted by this change, we need to grant the roles to `pem_agent` so that the job can be executed. If without the permission, the job would log error like below:
```
WARNING: [CheckServerCertificateExpiry]: Failed to get the expiry date with error: ERROR:  must be a member of pg_read_server_files to use this function
```