### PR TITLE
fix(PEM-6054): Migrate sslutils from Legacy RSA API to EVP API (CWE-477)

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -543,19 +543,17 @@ Datum
 openssl_rsa_generate_key(PG_FUNCTION_ARGS)
 {
 	int		 bits = PG_GETARG_INT32(0);
-	int		 ret = 0;
-	RSA		*rsa = NULL;
+	EVP_PKEY_CTX	*ctx = NULL;
+	EVP_PKEY	*pkey = NULL;
 	BIO		*bio = NULL;
 	const char	*err = NULL;
 	char		*data = NULL;
 	long		 len;
 	text		*res = NULL;
-	BIGNUM		*bne = NULL;
-	unsigned long	 rsa_f4 = RSA_F4;
 
 	/*
 	 * Don't allow too many bits.  It takes a long time, and since
-	 * RSA_generate_key() is an external library function, it's not
+	 * EVP_PKEY_keygen() is an external library function, it's not
 	 * interruptible.
 	 */
 	if (bits > 8192)
@@ -563,23 +561,26 @@ openssl_rsa_generate_key(PG_FUNCTION_ARGS)
 		        (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 		         errmsg("maximum number of bits is 8192")));
 
-	bne = BN_new();
-	ret = BN_set_word(bne, rsa_f4);
-
-	if(ret != 1)
+	/* Generate RSA key via EVP API (supported on OpenSSL 1.0.2 through 3.x). */
+	ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+	if (!ctx)
 	{
-		err = "BN_set_word";
+		err = "EVP_PKEY_CTX_new_id";
 		goto out;
 	}
-
-
-	/* Generate key. */
-	rsa = RSA_new();
-	ret = RSA_generate_key_ex(rsa, bits, bne, NULL);
-
-	if (ret != 1)
+	if (EVP_PKEY_keygen_init(ctx) <= 0)
 	{
-		err = "RSA_generate_key";
+		err = "EVP_PKEY_keygen_init";
+		goto out;
+	}
+	if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, bits) <= 0)
+	{
+		err = "EVP_PKEY_CTX_set_rsa_keygen_bits";
+		goto out;
+	}
+	if (EVP_PKEY_keygen(ctx, &pkey) <= 0)
+	{
+		err = "EVP_PKEY_keygen";
 		goto out;
 	}
 
@@ -592,9 +593,9 @@ openssl_rsa_generate_key(PG_FUNCTION_ARGS)
 	}
 
 	/* Write data to buffer. */
-	if (!PEM_write_bio_RSAPrivateKey(bio, rsa, NULL, NULL, 0, NULL, NULL))
+	if (!PEM_write_bio_PrivateKey(bio, pkey, NULL, NULL, 0, NULL, NULL))
 	{
-		err = "PEM_write_bio_RSAPrivateKey";
+		err = "PEM_write_bio_PrivateKey";
 		goto out;
 	}
 
@@ -604,12 +605,12 @@ openssl_rsa_generate_key(PG_FUNCTION_ARGS)
 
 	/* Get out, while trying not to leak memory. */
 out:
-	if (bne != NULL)
-		BN_free(bne);
+	if (ctx != NULL)
+		EVP_PKEY_CTX_free(ctx);
+	if (pkey != NULL)
+		EVP_PKEY_free(pkey);
 	if (bio != NULL)
 		BIO_free(bio);
-	if (rsa != NULL)
-		RSA_free(rsa);
 	if (err != NULL)
 		report_openssl_error((char *)err);
 	PG_RETURN_TEXT_P(res);
@@ -633,7 +634,6 @@ openssl_rsa_key_to_csr(PG_FUNCTION_ARGS)
 	text       *organization_unit = PG_GETARG_TEXT_PP(5);
 	text	   *email = PG_GETARG_TEXT_PP(6);
 	BIO		   *bio = NULL;
-	RSA		   *rsa = NULL;
 	char	   *err = NULL;
 	X509_REQ   *req = NULL;
 	EVP_PKEY   *evp = NULL;
@@ -642,19 +642,19 @@ openssl_rsa_key_to_csr(PG_FUNCTION_ARGS)
 	long		len;
 	text	   *res = NULL;
 
-	/* Decode key to RSA. */
+	/* Decode key from PEM directly into EVP_PKEY (algorithm-agnostic). */
 	bio = BIO_new_mem_buf(VARDATA_ANY(key), VARSIZE_ANY_EXHDR(key));
 	if (!bio)
 	{
 		err = "BIO_new_mem_buf";
 		goto out;
 	}
-	rsa = PEM_read_bio_RSAPrivateKey(bio, NULL, NULL, NULL);
+	evp = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
 	BIO_free(bio);
 	bio = NULL;
-	if (!rsa)
+	if (!evp)
 	{
-		err = "PEM_read_bio_RSAPrivateKey";
+		err = "PEM_read_bio_PrivateKey";
 		goto out;
 	}
 
@@ -663,19 +663,6 @@ openssl_rsa_key_to_csr(PG_FUNCTION_ARGS)
 	if (!req)
 	{
 		err = "X509_REQ_new";
-		goto out;
-	}
-
-	/* Use EVP_PKEY to bind RSA to X509_REQ. */
-	evp = EVP_PKEY_new();
-	if (!evp)
-	{
-		err = "EVP_PKEY_new";
-		goto out;
-	}
-	if (!EVP_PKEY_set1_RSA(evp, rsa))
-	{
-		err = "EVP_PKEY_assign_RSA";
 		goto out;
 	}
 
@@ -772,8 +759,6 @@ out:
 		EVP_PKEY_free(evp);
 	if (req != NULL)
 		X509_REQ_free(req);
-	if (rsa != NULL)
-		RSA_free(rsa);
 	if (bio != NULL)
 		BIO_free(bio);
 	if (err != NULL)
@@ -792,7 +777,6 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	text       *ca_cert_file_path = NULL;
 	text       *ca_key_file_path = NULL;
 	BIO        *bio = NULL;
-	RSA        *ca_key = NULL;
 	char       *err = NULL;
 	X509_REQ   *req = NULL;
 	X509       *ca_cert = NULL;
@@ -861,10 +845,10 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		err = "FILE_OPEN_CA_KEY";
 		goto out;
 	}
-	ca_key = PEM_read_bio_RSAPrivateKey(bio_key, NULL, NULL, NULL);
-	if (!ca_key)
+	pkey = PEM_read_bio_PrivateKey(bio_key, NULL, NULL, NULL);
+	if (!pkey)
 	{
-		err = "PEM_read_RSAPrivateKey";
+		err = "PEM_read_bio_PrivateKey";
 		goto out;
 	}
 
@@ -881,18 +865,6 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 	if (!req)
 	{
 		err = "PEM_read_bio_X509_REQ";
-		goto out;
-	}
-	/* Use EVP_PKEY to bind RSA to X509_REQ. */
-	pkey = EVP_PKEY_new();
-	if (!pkey)
-	{
-		err = "EVP_PKEY_new";
-		goto out;
-	}
-	if (!EVP_PKEY_set1_RSA(pkey, ca_key))
-	{
-		err = "EVP_PKEY_assign_RSA";
 		goto out;
 	}
 
@@ -1050,8 +1022,6 @@ out:
 		X509_REQ_free(req);
 	if (ca_cert != NULL)
 		X509_free(ca_cert);
-	if (ca_key != NULL)
-		RSA_free(ca_key);
 	if (bio != NULL)
 		BIO_free(bio);
 	if (extension != NULL)
@@ -1077,7 +1047,6 @@ openssl_rsa_generate_crl(PG_FUNCTION_ARGS)
 	text       *ca_cert_file_path = NULL;
 	text       *ca_key_file_path = NULL;
 	BIO        *bio = NULL;
-	RSA        *ca_key = NULL;
 	char       *err = NULL;
 	X509       *ca_cert = NULL;
 	char       *data = NULL;
@@ -1136,24 +1105,10 @@ openssl_rsa_generate_crl(PG_FUNCTION_ARGS)
 		err = "FILE_OPEN_CA_KEY";
 		goto out;
 	}
-	ca_key = PEM_read_bio_RSAPrivateKey(bio_key, NULL, NULL, NULL);
-	if (!ca_key)
-	{
-		err = "PEM_read_RSAPrivateKey";
-		goto out;
-	}
-
-
-	/* Use EVP_PKEY to bind RSA to X509_REQ. */
-	pkey = EVP_PKEY_new();
+	pkey = PEM_read_bio_PrivateKey(bio_key, NULL, NULL, NULL);
 	if (!pkey)
 	{
-		err = "EVP_PKEY_new";
-		goto out;
-	}
-	if (!EVP_PKEY_set1_RSA(pkey, ca_key))
-	{
-		err = "EVP_PKEY_assign_RSA";
+		err = "PEM_read_bio_PrivateKey";
 		goto out;
 	}
 
@@ -1231,8 +1186,6 @@ out:
 		EVP_PKEY_free(pkey);
 	if (ca_cert != NULL)
 		X509_free(ca_cert);
-	if (ca_key != NULL)
-		RSA_free(ca_key);
 	if (bio != NULL)
 		BIO_free(bio);
 	if (tmptm != NULL)


### PR DESCRIPTION
This PR is to use the new safe EVP API to replace deprecated RSA API for SSLUtils functions.

Tested on RHEL/9/arm64 EPAS-17, package: 
```
edb-as17-server-sslutils.aarch64   1.4-0.0snapshot26570777974.373.1.0a12e92.1.el9
```
Test scenarios:
1. Fresh installation, SSL cert/key can be generated and PEM agent can connect
2. Upgrade from PEM 10.4.2 and SSLUtils 1.4-1
* The old Agent can still connect
* New Agent can be registered and connect
* `openssl_revoke_certificate()` can work on old certificate
* `openssl_is_crt_expire_on()`  and `openssl_get_crt_expiry_date()` can work on old certificate