### PR TITLE
fix: the new code is not able to work on Windows

### DIFF
--- a/sslutils.c
+++ b/sslutils.c
@@ -35,7 +35,6 @@
 #include "utils/datetime.h"
 #include "utils/guc.h"
 #include "utils/varlena.h"
-#include "utils/elog.h"
 
 #ifdef WIN32
 #include <time.h>
@@ -196,17 +195,13 @@ static char* string_sep(char **stringp, const char *delim)
 static bool validate_path_within_dedicated_dir(const char *path, char *dedicated_dir)
 {
 #ifdef WIN32
-	elog(LOG, "Start validating if path in dedicated dir\n");
 	char resolved[MAX_PATH], datadir_resolved[MAX_PATH];
 
-	elog(LOG, "Validate path: %s to %s\n", path, dedicated_dir);
 	// GetFullPathNameA returns 0 on failure.
 	if (GetFullPathNameA(path, MAX_PATH, resolved, NULL) == 0 ||
 		GetFullPathNameA(dedicated_dir, MAX_PATH, datadir_resolved, NULL) == 0) {
-		elog(LOG, "GetFullPathNameA got failure");
 		return false;
 	}
-	elog(LOG, "Resolved path: %s to %s\n", resolved, datadir_resolved);
 
 	size_t dir_len = strlen(datadir_resolved);
 
@@ -219,9 +214,6 @@ static bool validate_path_within_dedicated_dir(const char *path, char *dedicated
 			dir_len++;
 		}
 	}
-
-	elog(LOG, "Refined path: %s to %s\n", resolved, datadir_resolved);
-	elog(LOG, "Compare length: %d\n", dir_len);
 
 	// Windows paths are case-insensitive. _strnicmp compares up to 'dir_len' characters.
 	return _strnicmp(resolved, datadir_resolved, dir_len) == 0;
@@ -1392,9 +1384,6 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	List* elemlist;
 	ListCell* l;
 
-	elog(LOG, "Start validating if target in GUC configured dir\n");
-	elog(LOG, "validate path: %s to %s\n", target, guc_string);
-
 	rawstring = pstrdup(guc_string);
 
 	// It handles case-insensitivity and whitespace automatically
@@ -1407,7 +1396,6 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	foreach(l, elemlist)
 	{
 		char* dir = (char*) lfirst(l);
-		elog(LOG, "comparing path: %s to %s\n", target, dir);
 #ifdef WIN32
 		if (_strnicmp(target, dir, strlen(dir)) == 0)
 #else
@@ -1416,7 +1404,6 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 		{
 			pfree(rawstring);
 			list_free(elemlist);
-			elog(LOG, "Matched!\n");
 			return true;
 		}
 	}

--- a/sslutils.c
+++ b/sslutils.c
@@ -195,18 +195,18 @@ static char* string_sep(char **stringp, const char *delim)
 static bool validate_path_within_dedicated_dir(const char *path, char *dedicated_dir)
 {
 #ifdef WIN32
-	fprintf(stdout, "Start validating if path in dedicated dir\n");
+	fprintf(stderr, "Start validating if path in dedicated dir\n");
 	char resolved[MAX_PATH], datadir_resolved[MAX_PATH];
 
-	fprintf(stdout, "Validate path: %s to %s\n", path, dedicated_dir);
+	fprintf(stderr, "Validate path: %s to %s\n", path, dedicated_dir);
 	// GetFullPathNameA returns 0 on failure.
 	if (GetFullPathNameA(path, MAX_PATH, resolved, NULL) == 0 ||
 		GetFullPathNameA(dedicated_dir, MAX_PATH, datadir_resolved, NULL) == 0) {
-		fprintf(stdout, "GetFullPathNameA got failure");
-		fflush(stdout);
+		fprintf(stderr, "GetFullPathNameA got failure");
+		fflush(stderr);
 		return false;
 	}
-	fprintf(stdout, "Resolved path: %s to %s\n", resolved, datadir_resolved);
+	fprintf(stderr, "Resolved path: %s to %s\n", resolved, datadir_resolved);
 
 	size_t dir_len = strlen(datadir_resolved);
 
@@ -220,9 +220,9 @@ static bool validate_path_within_dedicated_dir(const char *path, char *dedicated
 		}
 	}
 
-	fprintf(stdout, "Refined path: %s to %s\n", resolved, datadir_resolved);
-	fprintf(stdout, "Compare length: %d\n", dir_len);
-	fflush(stdout);
+	fprintf(stderr, "Refined path: %s to %s\n", resolved, datadir_resolved);
+	fprintf(stderr, "Compare length: %d\n", dir_len);
+	fflush(stderr);
 
 	// Windows paths are case-insensitive. _strnicmp compares up to 'dir_len' characters.
 	return _strnicmp(resolved, datadir_resolved, dir_len) == 0;
@@ -1393,8 +1393,8 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	List* elemlist;
 	ListCell* l;
 
-	fprintf(stdout, "Start validating if target in GUC configured dir\n");
-	fprintf(stdout, "validate path: %s to %s\n", target, guc_string);
+	fprintf(stderr, "Start validating if target in GUC configured dir\n");
+	fprintf(stderr, "validate path: %s to %s\n", target, guc_string);
 
 	rawstring = pstrdup(guc_string);
 
@@ -1402,26 +1402,27 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	if (!SplitIdentifierString(rawstring, ',', &elemlist))
 	{
 		pfree(rawstring);
+		fflush(stderr);
 		return false;
 	}
 
 	foreach(l, elemlist)
 	{
 		char* dir = (char*) lfirst(l);
-		fprintf(stdout, "comparing path: %s to %s\n", target, dir);
+		fprintf(stderr, "comparing path: %s to %s\n", target, dir);
 		if (strncmp(target, dir, strlen(dir)) == 0)
 		{
 			pfree(rawstring);
 			list_free(elemlist);
-			fprintf(stdout, "Matched!\n");
-			fflush(stdout);
+			fprintf(stderr, "Matched!\n");
+			fflush(stderr);
 			return true;
 		}
 	}
 
 	pfree(rawstring);
 	list_free(elemlist);
-	fflush(stdout);
+	fflush(stderr);
 	return false;
 }
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -1408,7 +1408,11 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	{
 		char* dir = (char*) lfirst(l);
 		elog(LOG, "comparing path: %s to %s\n", target, dir);
+#ifdef WIN32
+		if (_strnicmp(target, dir, strlen(dir)) == 0)
+#else
 		if (strncmp(target, dir, strlen(dir)) == 0)
+#endif
 		{
 			pfree(rawstring);
 			list_free(elemlist);

--- a/sslutils.c
+++ b/sslutils.c
@@ -35,6 +35,7 @@
 #include "utils/datetime.h"
 #include "utils/guc.h"
 #include "utils/varlena.h"
+#include "utils/elog.h"
 
 #ifdef WIN32
 #include <time.h>
@@ -195,18 +196,17 @@ static char* string_sep(char **stringp, const char *delim)
 static bool validate_path_within_dedicated_dir(const char *path, char *dedicated_dir)
 {
 #ifdef WIN32
-	fprintf(stderr, "Start validating if path in dedicated dir\n");
+	elog(LOG, "Start validating if path in dedicated dir\n");
 	char resolved[MAX_PATH], datadir_resolved[MAX_PATH];
 
-	fprintf(stderr, "Validate path: %s to %s\n", path, dedicated_dir);
+	elog(LOG, "Validate path: %s to %s\n", path, dedicated_dir);
 	// GetFullPathNameA returns 0 on failure.
 	if (GetFullPathNameA(path, MAX_PATH, resolved, NULL) == 0 ||
 		GetFullPathNameA(dedicated_dir, MAX_PATH, datadir_resolved, NULL) == 0) {
-		fprintf(stderr, "GetFullPathNameA got failure");
-		fflush(stderr);
+		elog(LOG, "GetFullPathNameA got failure");
 		return false;
 	}
-	fprintf(stderr, "Resolved path: %s to %s\n", resolved, datadir_resolved);
+	elog(LOG, "Resolved path: %s to %s\n", resolved, datadir_resolved);
 
 	size_t dir_len = strlen(datadir_resolved);
 
@@ -220,9 +220,8 @@ static bool validate_path_within_dedicated_dir(const char *path, char *dedicated
 		}
 	}
 
-	fprintf(stderr, "Refined path: %s to %s\n", resolved, datadir_resolved);
-	fprintf(stderr, "Compare length: %d\n", dir_len);
-	fflush(stderr);
+	elog(LOG, "Refined path: %s to %s\n", resolved, datadir_resolved);
+	elog(LOG, "Compare length: %d\n", dir_len);
 
 	// Windows paths are case-insensitive. _strnicmp compares up to 'dir_len' characters.
 	return _strnicmp(resolved, datadir_resolved, dir_len) == 0;
@@ -1393,8 +1392,8 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	List* elemlist;
 	ListCell* l;
 
-	fprintf(stderr, "Start validating if target in GUC configured dir\n");
-	fprintf(stderr, "validate path: %s to %s\n", target, guc_string);
+	elog(LOG, "Start validating if target in GUC configured dir\n");
+	elog(LOG, "validate path: %s to %s\n", target, guc_string);
 
 	rawstring = pstrdup(guc_string);
 
@@ -1402,27 +1401,24 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	if (!SplitIdentifierString(rawstring, ',', &elemlist))
 	{
 		pfree(rawstring);
-		fflush(stderr);
 		return false;
 	}
 
 	foreach(l, elemlist)
 	{
 		char* dir = (char*) lfirst(l);
-		fprintf(stderr, "comparing path: %s to %s\n", target, dir);
+		elog(LOG, "comparing path: %s to %s\n", target, dir);
 		if (strncmp(target, dir, strlen(dir)) == 0)
 		{
 			pfree(rawstring);
 			list_free(elemlist);
-			fprintf(stderr, "Matched!\n");
-			fflush(stderr);
+			elog(LOG, "Matched!\n");
 			return true;
 		}
 	}
 
 	pfree(rawstring);
 	list_free(elemlist);
-	fflush(stderr);
 	return false;
 }
 

--- a/sslutils.c
+++ b/sslutils.c
@@ -1020,7 +1020,11 @@ openssl_csr_to_crt(PG_FUNCTION_ARGS)
 		goto out;
 	}
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	if (!BN_rand(bn, SERIAL_RAND_BITS, -1, 0))
+#else
 	if (!BN_rand(bn, SERIAL_RAND_BITS, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY))
+#endif
 	{
 		err = "Error_generating_random_bignum";
 		goto out;

--- a/sslutils.c
+++ b/sslutils.c
@@ -189,11 +189,36 @@ static char* string_sep(char **stringp, const char *delim)
  */
 static bool validate_path_within_dedicated_dir(const char *path, char *dedicated_dir)
 {
+#ifdef WIN32
+	char resolved[MAX_PATH], datadir_resolved[MAX_PATH];
+
+	// GetFullPathNameA returns 0 on failure.
+	if (GetFullPathNameA(path, MAX_PATH, resolved, NULL) == 0 ||
+		GetFullPathNameA(dedicated_dir, MAX_PATH, datadir_resolved, NULL) == 0) {
+		return false;
+	}
+
+	size_t dir_len = strlen(datadir_resolved);
+
+	// Security fix/Edge case: Ensure datadir ends with a trailing backslash
+	// to prevent partial name matching (e.g., "C:\data" matching "C:\datadir")
+	if (dir_len > 0 && datadir_resolved[dir_len - 1] != '\\') {
+		// If there's room, add the trailing slash for an exact directory match
+		if (dir_len + 1 < MAX_PATH) {
+			strcat_s(datadir_resolved, MAX_PATH, "\\");
+			dir_len++;
+		}
+	}
+
+	// Windows paths are case-insensitive. _strnicmp compares up to 'dir_len' characters.
+	return _strnicmp(resolved, datadir_resolved, dir_len) == 0;
+#else
 	char resolved[PATH_MAX], datadir_resolved[PATH_MAX];
 	if (!realpath(path, resolved) || !realpath(dedicated_dir, datadir_resolved))
 		return false;
 
 	return strncmp(resolved, datadir_resolved, strlen(datadir_resolved)) == 0;
+#endif
 }
 
 /*
@@ -299,6 +324,7 @@ static int revoke_client_certificate(const char* dbfile, X509* x)
 	if (revoke_file == NULL)
 		return -1;
 
+#ifndef WIN32
 	if (flock(fileno(revoke_file), LOCK_EX | LOCK_NB) != 0)
 	{
 		if (errno == EWOULDBLOCK) {
@@ -306,6 +332,7 @@ static int revoke_client_certificate(const char* dbfile, X509* x)
 		}
 		return -1;
 	}
+#endif
 
 	// Lookup whether the client cert has been revoke by serial number
 	// and rotate the index.txt

--- a/sslutils.c
+++ b/sslutils.c
@@ -36,6 +36,11 @@
 #include "utils/guc.h"
 #include "utils/varlena.h"
 
+#ifdef WIN32
+#include <time.h>
+#define timegm _mkgmtime
+#endif
+
 // Start from PG-16, VARDATA_ANY was moved from postgres.h to varatt.h
 #if PG_VERSION_NUM >= 160000
 #include "varatt.h"

--- a/sslutils.c
+++ b/sslutils.c
@@ -195,13 +195,18 @@ static char* string_sep(char **stringp, const char *delim)
 static bool validate_path_within_dedicated_dir(const char *path, char *dedicated_dir)
 {
 #ifdef WIN32
+	fprintf(stdout, "Start validating if path in dedicated dir\n");
 	char resolved[MAX_PATH], datadir_resolved[MAX_PATH];
 
+	fprintf(stdout, "Validate path: %s to %s\n", path, dedicated_dir);
 	// GetFullPathNameA returns 0 on failure.
 	if (GetFullPathNameA(path, MAX_PATH, resolved, NULL) == 0 ||
 		GetFullPathNameA(dedicated_dir, MAX_PATH, datadir_resolved, NULL) == 0) {
+		fprintf(stdout, "GetFullPathNameA got failure");
+		fflush(stdout);
 		return false;
 	}
+	fprintf(stdout, "Resolved path: %s to %s\n", resolved, datadir_resolved);
 
 	size_t dir_len = strlen(datadir_resolved);
 
@@ -214,6 +219,10 @@ static bool validate_path_within_dedicated_dir(const char *path, char *dedicated
 			dir_len++;
 		}
 	}
+
+	fprintf(stdout, "Refined path: %s to %s\n", resolved, datadir_resolved);
+	fprintf(stdout, "Compare length: %d\n", dir_len);
+	fflush(stdout);
 
 	// Windows paths are case-insensitive. _strnicmp compares up to 'dir_len' characters.
 	return _strnicmp(resolved, datadir_resolved, dir_len) == 0;
@@ -1384,6 +1393,9 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	List* elemlist;
 	ListCell* l;
 
+	fprintf(stdout, "Start validating if target in GUC configured dir\n");
+	fprintf(stdout, "validate path: %s to %s\n", target, guc_string);
+
 	rawstring = pstrdup(guc_string);
 
 	// It handles case-insensitivity and whitespace automatically
@@ -1396,16 +1408,20 @@ static bool validate_path_within_allowed_guc(char* guc_string, const char* targe
 	foreach(l, elemlist)
 	{
 		char* dir = (char*) lfirst(l);
+		fprintf(stdout, "comparing path: %s to %s\n", target, dir);
 		if (strncmp(target, dir, strlen(dir)) == 0)
 		{
 			pfree(rawstring);
 			list_free(elemlist);
+			fprintf(stdout, "Matched!\n");
+			fflush(stdout);
 			return true;
 		}
 	}
 
 	pfree(rawstring);
 	list_free(elemlist);
+	fflush(stdout);
 	return false;
 }
 


### PR DESCRIPTION
This PR is to fix some issues on Windows:
1. Windows has no function: `timegm`, the equivalent is `_mkgmtime`
2. Windows need a different implementation for `validate_path_within_dedicated_dir` using Windows specific API: `GetFullPathNameA`
3. Windows path is case insensitive, shall use `_strnicmp` to compare paths
4. EPAS-14 for Windows is using OpenSSL 1.0.2 which doesn't have macro like `BN_RAND_TOP_ANY` and `BN_RAND_BOTTOM_ANY`, the equivalent is `-1` and `0`
5. `flock(fileno(revoke_file))` is not supported API on Windows, this code section is to avoid race condition in `revoke_client_certificate`. Consider this function is called when the certificate expires, and certificate expiration occurs approximately every few years, the race condition can rarely happen, so I simply disable this check for Windows.

The change has been verified on Windows, and it has no impact for Linux platforms.